### PR TITLE
Fix timeout on stream end

### DIFF
--- a/lib/readable_streambuffer.js
+++ b/lib/readable_streambuffer.js
@@ -39,6 +39,7 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
     if(size === 0 && that.stopped) {
       that.push(null);
+      allowPush = sendMore = false;
     }
 
     if (sendMore) {
@@ -57,6 +58,12 @@ var ReadableStreamBuffer = module.exports = function(opts) {
 
     if (size === 0) {
       this.push(null);
+    }
+
+    if (sendData.timeout) {
+      clearTimeout(sendData.timeout);
+      sendData.timeout = null;
+      sendData();
     }
   };
 


### PR DESCRIPTION
- Avoid extra timeout if the stream is stopped 
- immediately invoke `sendData` on stream end